### PR TITLE
Added an option for an output path

### DIFF
--- a/R/cite_packages.R
+++ b/R/cite_packages.R
@@ -15,16 +15,19 @@
 #' \dontrun{
 #' library(grateful)
 #' cite_packages()
-#' cite_packages(style = "ecology", out.format = "docx")
+#' cite_packages(style = "ecology", out.format = "docx", out.dir = getwd())
 #' }
 cite_packages <- function(all.pkg = TRUE, include.rmd = TRUE, style = NULL,
-                          out.format = "html", ...) {
-
+                          out.format = "html", out.dir = getwd(), ...) {
   pkgs <- scan_packages(all.pkgs = all.pkg, include.Rmd = include.rmd, ...)
-  cites <- get_citations(pkgs) # produces "pkg-refs.bib" file
-  rmd <- create_rmd(cites, csl = style)  # produces "refs.Rmd"
-  render_citations(rmd, output = out.format)
+  cites <- get_citations(pkgs, out.dir = out.dir) # produces "pkg-refs.bib" file
+  rmd <- create_rmd(cites, csl = style, out.dir = out.dir) # produces "refs.Rmd"
 
-  file.remove(rmd)
-
+  if (out.format == "rmd" | out.format == "Rmd") {
+    return(rmd) # Keep the rmarkdown file and return the file object
+  }
+  else {
+    render_citations(rmd, output = out.format, out.dir = out.dir)
+    file.remove(rmd)
+  }
 }

--- a/R/create_rmd.R
+++ b/R/create_rmd.R
@@ -16,13 +16,19 @@
 #' rmd <- create_rmd(cites)
 #' }
 create_rmd <- function(bib.list, bibfile = "pkg-refs.bib", csl = NULL,
-                       filename = "refs.Rmd") {
+                       filename = "refs.Rmd", out.dir = getwd()) {
 
   use.csl <- ifelse(is.null(csl), "#csl: null", "csl: ")
 
   # ensure CSL file is available, otherwise download
   if (!is.null(csl))
-    if (!file.exists(file.path(getwd(), paste0(csl, ".csl")))) get_csl(csl)
+    if (!file.exists(file.path(out.dir, paste0(csl, ".csl")))) get_csl(csl)
+
+  if (out.dir != getwd()) {
+    bibfile = file.path(out.dir, bibfile)
+    csl = file.path(out.dir, csl)
+    filename = file.path(out.dir, filename)
+  }
 
   yaml.header <- c(
     "---",

--- a/R/get_citations.R
+++ b/R/get_citations.R
@@ -13,7 +13,7 @@
 #' pkgs <- scan_packages()
 #' cites <- get_citations(pkgs)
 #' }
-get_citations <- function(pkgs, filename = "pkg-refs.bib") {
+get_citations <- function(pkgs, filename = "pkg-refs.bib", out.dir = getwd()) {
 
   cites <- lapply(pkgs, utils::citation)
   cites.bib <- lapply(cites, utils::toBibtex)
@@ -24,7 +24,7 @@ get_citations <- function(pkgs, filename = "pkg-refs.bib") {
   }
 
   ## write bibtex references to file
-  writeLines(enc2utf8(unlist(cites.bib)), con = filename, useBytes = TRUE)
+  writeLines(enc2utf8(unlist(cites.bib)), con = file.path(out.dir, filename), useBytes = TRUE)
 
   ## return named list of bibtex references
   names(cites.bib) <- pkgs

--- a/R/render_citations.R
+++ b/R/render_citations.R
@@ -13,16 +13,17 @@
 #' pkgs <- scan_packages()
 #' cites <- get_citations(pkgs)
 #' rmd <- create_rmd(cites)
-#' render_citations(rmd, output = "html")
+#' render_citations(rmd, output = "html", out.dir = getwd())
 #' }
-render_citations <- function(rmd, output = "html") {
+render_citations <- function(rmd, output = "html", out.dir = getwd()) {
+  if (output == "docx") out.format <- "word_document"
+  if (output == "pdf") out.format <- "pdf_document"
+  if (output == "html") out.format <- "html_document"
+  if (output == "md") out.format <- "md_document"
 
-  if (output == "docx") out.format = "word_document"
-  if (output == "pdf") out.format = "pdf_document"
-  if (output == "html") out.format = "html_document"
-  if (output == "md") out.format = "md_document"
-
-  rmarkdown::render(input = rmd, output_format = out.format,
-                    output_file = paste0("citations.", output),
-                    output_dir = getwd())
+  rmarkdown::render(
+    input = rmd, output_format = out.format,
+    output_file = paste0("citations.", output),
+    output_dir = out.dir
+  )
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -39,10 +39,17 @@ cite_packages()
 
 ![](example-output.PNG)
 
-This document can also be a Word document, or PDF, or markdown. And use the citation style of a particular journal:
+This document can also be a Word document, PDF file, markdown file, or Rmarkdown file. And use the citation style of a particular journal:
 
 ```{r eval = FALSE}
 cite_packages(style = "ecology", out.format = "docx")
+```
+
+You can also save the output of `cite_packages` to a specified directory.
+
+```{r eval = FALSE}
+# Save the output in Rmarkdown format only and to a docs folder.
+cite_packages(out.format = "rmd", out.dir = file.path(getwd(), "docs"))
 ```
 
 
@@ -73,7 +80,3 @@ rmd <- create_rmd(cites)
 ```{r}
 render_citations(rmd, output = "html")
 ```
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -24,10 +24,17 @@ cite_packages()
 
 ![](example-output.PNG)
 
-This document can also be a Word document, or PDF, or markdown. And use the citation style of a particular journal:
+This document can also be a Word document, PDF file, markdown file, or Rmarkdown file. And use the citation style of a particular journal:
 
 ``` r
 cite_packages(style = "ecology", out.format = "docx")
+```
+
+You can also save the output of `cite_packages` to a specified directory.
+
+``` r
+# Save the output in Rmarkdown format only and to a docs folder.
+cite_packages(out.format = "rmd", out.dir = file.path(getwd(), "docs"))
 ```
 
 Workflow


### PR DESCRIPTION
This PR address issue #13

- Add an option for an output path named `out.dir`
- Added ability for user to use `rmd` or `Rmd` as `out.format` to only generate the `.Rmd` file and `.bib` file.
- Updated `README.Rmd` and regenerated `README.md` with 3 lines on using the `out.dir` parameter

<hr>

@Pakillo I hope this suffices. It keeps the default output as the working directory with `getwd()` so nothing will change for users at all unless they specify an `out.dir`.

Thanks for allowing me to contribute.