### PR TITLE
Return citation paragraph asis, add Connor's ORCiD

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,10 +23,9 @@ Imports:
   rmarkdown,
   utils
 Suggests: 
-    covr,
     rstudioapi,
     testthat (>= 3.0.0)
 URL: https://pakillo.github.io/grateful
 BugReports: https://github.com/Pakillo/grateful/issues
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Date: 2022-02-09
 Authors@R: c(
     person('Francisco', 'Rodriguez-Sanchez', email = 'f.rodriguez.sanc@gmail.com', 
             role = c('aut', 'cre'), comment = c(ORCID = "0000-0002-7981-1599")),
-    person('Connor P.', 'Jackson', email = 'cpjackson@berkeley.edu', role = 'aut'),
+    person('Connor P.', 'Jackson', email = 'connor@cpjackson.net', role = 'aut',
+           comment = c(ORCID = "0000-0002-4220-5210")),
     person('Shaurita D.', 'Hutchins', role = c('ctb')))
 Description: Facilitates citation of R packages used in analysis projects. 
     Scans project for packages used, gets their citations, and produces 

--- a/R/cite_packages.R
+++ b/R/cite_packages.R
@@ -119,7 +119,7 @@
 #'
 #' # include this in YAML header: bibliography: grateful-refs.bib
 #'
-#' # then call cite_packages within a chunk with chunk option results = "asis"
+#' # then call cite_packages within an R chunk:
 #' cite_packages(output = "paragraph")
 #'
 #'
@@ -164,7 +164,9 @@ cite_packages <- function(output = c("file", "paragraph", "table", "citekeys"),
   }
 
   if (output == "paragraph") {
-    cat(write_citation_paragraph(pkgs.df, include.RStudio = include.RStudio))
+    paragraph <- write_citation_paragraph(pkgs.df,
+                                          include.RStudio = include.RStudio)
+    return(knitr::asis_output(paragraph))
   }
 
   if (output == "table") {

--- a/R/nocite_references.R
+++ b/R/nocite_references.R
@@ -57,7 +57,7 @@ nocite_references <- function(citekeys, citation_processor = c('pandoc', 'latex'
     nocite_command <- c("---\nnocite: |\n\t", nocites, "\n...")
   } else if (tolower(citation_processor) == 'latex') {
     nocites <- paste0(citekeys, collapse = ", ")
-    nocite_command <- c("\\nocite{", nocites, "}")
+    nocite_command <- paste("\\nocite{", nocites, "}")
   } else stop("Invalid citation processing style.")
   knitr::asis_output(nocite_command)
 }

--- a/R/nocite_references.R
+++ b/R/nocite_references.R
@@ -54,10 +54,10 @@ nocite_references <- function(citekeys, citation_processor = c('pandoc', 'latex'
 
   if (tolower(citation_processor) == 'pandoc') {
     nocites <- paste0("@", citekeys, collapse = ", ")
-    nocite_command <- c("---\nnocite: |\n\t", nocites, "\n...")
+    nocite_command <- paste("---\nnocite: |\n\t", nocites, "\n...")
   } else if (tolower(citation_processor) == 'latex') {
     nocites <- paste0(citekeys, collapse = ", ")
-    nocite_command <- paste("\\nocite{", nocites, "}")
+    nocite_command <- paste0("\\nocite{", nocites, "}")
   } else stop("Invalid citation processing style.")
   knitr::asis_output(nocite_command)
 }

--- a/R/utils_citations.R
+++ b/R/utils_citations.R
@@ -1,6 +1,22 @@
+# fix formatting of titles for bibtex
+fix_title <- function(titlestring) {
+  # maintain capitalization of package name at the beginning
+  titlestring <- gsub("^ *title ?= ?\\{([a-zA-Z._]*):", "title = \\{\\{\\1\\}:", titlestring)
+  # always capitalize "R"
+  titlestring <- gsub(" R([^a-zA-Z0-9])", " \\{R\\}\\1", titlestring)
+  # get opening and closing quotation marks right, and preserve capitalization
+  titlestring <- gsub("[`']([^`']*)[`']", "`\\{\\1\\}'", titlestring)
+  titlestring <- gsub('"([^"]*)"', "``\\{\\1\\}''", titlestring)
+  return(titlestring)
+}
+
 # for a name and citation, create unique citekey for each citation
 add_citekey <- function(pkg_name, citation) {
+  # fix the titles with proper bibtex formatting
   citation_bibtex <- utils::toBibtex(citation)
+  title_rows <- (names(citation_bibtex) == "title")
+  citation_bibtex[title_rows] <- fix_title(citation_bibtex[title_rows])
+
   refbeginnings <- grep(pattern = "\\{,$", x = citation_bibtex)
   for (i in 1:length(refbeginnings)) {
     if (length(refbeginnings) == 1) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -87,10 +87,10 @@ bibliography:
 - grateful-refs.bib
 ```
 
-Then call `cite_packages(output = "paragraph")` within a code chunk (specifying chunk option: `results = "asis"`) to automatically include a paragraph mentioning all the used packages, and include their references in the bibliography list. 
+Then call `cite_packages(output = "paragraph")` within a code chunk (block or inline) to automatically include a paragraph mentioning all the used packages, and include their references in the bibliography list. 
 
 ````
-```{r results = 'asis'}`r ''`
+```{r}`r ''`
 cite_packages(output = "paragraph")
 ```
 ````

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ First, include a reference to the BibTeX file in your YAML header.
     - grateful-refs.bib
 
 Then call `cite_packages(output = "paragraph")` within a code chunk
-(specifying chunk option: `results = "asis"`) to automatically include a
-paragraph mentioning all the used packages, and include their references
-in the bibliography list.
+(block or inline) to automatically include a paragraph mentioning all
+the used packages, and include their references in the bibliography
+list.
 
-    ```{r results = 'asis'}
+    ```{r}
     cite_packages(output = "paragraph")
     ```
 
@@ -114,7 +114,7 @@ citations, using `output = 'table'`:
     kable(pkgs)
     ```
 
-<img src="man/figures/table.png" width="1271" />
+![](man/figures/table.png)<!-- -->
 
 If you want the references to appear in a particular format, you can
 specify the citation style in the YAML header:
@@ -137,17 +137,17 @@ Use `scan_packages`
 
 ``` r
 scan_packages()
-          pkg version
-1        base   4.1.2
-2        covr   3.5.1
-3    grateful  0.1.10
-4       knitr    1.37
-5     pkgdown   2.0.2
-6     remotes   2.4.2
-7        renv  0.15.2
-8   rmarkdown    2.11
-9  rstudioapi    0.13
-10   testthat   3.1.2
+         pkg version
+1       base   4.1.2
+2       covr   3.5.1
+3   grateful  0.1.11
+4      knitr    1.37
+5    pkgdown   2.0.2
+6    remotes   2.4.2
+7       renv  0.15.2
+8  rmarkdown    2.11
+9   testthat   3.1.2
+10 tidyverse   1.3.1
 ```
 
 ### Producing a BibTeX file with package references

--- a/README.md
+++ b/README.md
@@ -137,17 +137,16 @@ Use `scan_packages`
 
 ``` r
 scan_packages()
-         pkg version
-1       base   4.1.2
-2       covr   3.5.1
-3   grateful  0.1.11
-4      knitr    1.37
-5    pkgdown   2.0.2
-6    remotes   2.4.2
-7       renv  0.15.2
-8  rmarkdown    2.11
-9   testthat   3.1.2
-10 tidyverse   1.3.1
+        pkg version
+1      base   4.2.1
+2  grateful  0.1.11
+3     knitr    1.39
+4   pkgdown   2.0.6
+5   remotes   2.4.2
+6      renv  0.15.5
+7 rmarkdown    2.14
+8  testthat   3.1.4
+9 tidyverse   1.3.1
 ```
 
 ### Producing a BibTeX file with package references
@@ -163,8 +162,8 @@ If you want to get the BibTeX references for a few specific packages:
 ``` r
 get_pkgs_info(pkgs = c("lme4", "vegan"))
 #>     pkg version citekeys
-#> 1  lme4  1.1.28     lme4
-#> 2 vegan   2.5.7    vegan
+#> 1  lme4  1.1.30     lme4
+#> 2 vegan   2.6.2    vegan
 ```
 
 ### Using grateful with the tidyverse

--- a/man/cite_packages.Rd
+++ b/man/cite_packages.Rd
@@ -142,7 +142,7 @@ cite_packages(pkgs = c("lme4", "vegan", "mgcv"))
 
 # include this in YAML header: bibliography: grateful-refs.bib
 
-# then call cite_packages within a chunk with chunk option results = "asis"
+# then call cite_packages within an R chunk:
 cite_packages(output = "paragraph")
 
 


### PR DESCRIPTION
- The `output = "paragraph"` functionality required declaring a `results='asis'` chunk, but we can set this feature ourselves by wrapping in `asis_output()` and just returning the string.
- Adding Connor Jackson's ORCiD to the DESCRIPTION file