### PR TITLE
Add passive voice option to citation paragraph

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Authors@R: c(
             comment = c(ORCID = "0000-0002-7981-1599")),
     person("Connor P.", "Jackson", email = "connor@cpjackson.net", role = "aut",
            comment = c(ORCID = "0000-0002-4220-5210")),
-    person("Shaurita D.", "Hutchins", role = "ctb")
+    person("Shaurita D.", "Hutchins", role = "ctb"),
+    person("James M.", "Clawson", role = "ctb")
   )
 Description: Facilitates the citation of R packages used in analysis
     projects. Scans project for packages used, gets their citations, and

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: grateful
 Title: Facilitate Citation of R Packages
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(
     person("Francisco", "Rodriguez-Sanchez", 
             email = "f.rodriguez.sanc@gmail.com", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 
+# grateful 0.2.1
+
+* Citation paragraph can now be written in passive voice, thanks to @jmclawson
+
+
 # grateful 0.2.0
 
 * Added `omit` argument to exclude some packages from the citation report. 

--- a/R/cite_packages.R
+++ b/R/cite_packages.R
@@ -100,6 +100,9 @@
 #' @param include.RStudio Logical. If `TRUE`, adds a citation for the
 #'   current version of RStudio.
 #'
+#' @param passive.voice Logical. If `TRUE`, uses passive voice in any paragraph  
+#'   generated for citations.
+#'
 #' @param out.file Desired name of the citation report to be created if
 #' `output = "file"`. Default is "grateful-report" (without extension).
 #'
@@ -158,6 +161,7 @@ cite_packages <- function(output = c("file", "paragraph", "table", "citekeys"),
                           cite.tidyverse = TRUE,
                           dependencies = FALSE,
                           include.RStudio = FALSE,
+                          passive.voice = FALSE,
                           out.file = "grateful-report",
                           bib.file = "grateful-refs",
                           ...) {
@@ -204,7 +208,8 @@ cite_packages <- function(output = c("file", "paragraph", "table", "citekeys"),
   if (output == "paragraph") {
 
     paragraph <- write_citation_paragraph(pkgs.df,
-                                          include.RStudio = include.RStudio)
+                                          include.RStudio = include.RStudio,
+                                          passive.voice = passive.voice)
     return(knitr::asis_output(paragraph))
 
   }

--- a/R/write_citation_paragraph.R
+++ b/R/write_citation_paragraph.R
@@ -1,4 +1,4 @@
-write_citation_paragraph <- function(df, include.RStudio = FALSE) {
+write_citation_paragraph <- function(df, include.RStudio = FALSE, passive.voice = FALSE) {
 
   df.pkgs <- df[df$pkg != "base", ]
 
@@ -6,17 +6,26 @@ write_citation_paragraph <- function(df, include.RStudio = FALSE) {
     rversion <- paste0("R version ",
                        get_version("base", df), " ",
                        get_citekeys("base", df),
-                       " and ")
+                       " ")
   } else {
     rversion <- ""
   }
 
-  parag <- paste0(
-    "We used ",
+  if (passive.voice) {
+    parag <- paste0(
+    "This work was completed using ",
     rversion,
-    "the following R packages: ",
+    "with the following R packages: ",
     paste(format_pkg_citation(pkgname = df.pkgs$pkg, df), collapse = ", ")
   )
+  } else {
+    parag <- paste0(
+    "We used ",
+    rversion,
+    "and the following R packages: ",
+    paste(format_pkg_citation(pkgname = df.pkgs$pkg, df), collapse = ", ")
+  )
+  }
 
   if (include.RStudio) {
     parag <- paste0(parag, ", running in RStudio v. ", rstudioapi::versionInfo()$version,

--- a/R/write_citation_paragraph.R
+++ b/R/write_citation_paragraph.R
@@ -2,29 +2,36 @@ write_citation_paragraph <- function(df, include.RStudio = FALSE, passive.voice 
 
   df.pkgs <- df[df$pkg != "base", ]
 
+  rversion <- ""
+
   if ("base" %in% df$pkg) {
+
     rversion <- paste0("R version ",
                        get_version("base", df), " ",
                        get_citekeys("base", df),
                        " ")
-  } else {
-    rversion <- ""
+
+    if (passive.voice) {
+      rversion <- paste0("using ", rversion)
+    } else {
+      rversion <- paste0(rversion, "and ")
+    }
   }
 
   if (passive.voice) {
     parag <- paste0(
-    "This work was completed using ",
-    rversion,
-    "with the following R packages: ",
-    paste(format_pkg_citation(pkgname = df.pkgs$pkg, df), collapse = ", ")
-  )
+      "This work was completed ",
+      rversion,
+      "with the following R packages: ",
+      paste(format_pkg_citation(pkgname = df.pkgs$pkg, df), collapse = ", ")
+    )
   } else {
     parag <- paste0(
-    "We used ",
-    rversion,
-    "and the following R packages: ",
-    paste(format_pkg_citation(pkgname = df.pkgs$pkg, df), collapse = ", ")
-  )
+      "We used ",
+      rversion,
+      "the following R packages: ",
+      paste(format_pkg_citation(pkgname = df.pkgs$pkg, df), collapse = ", ")
+    )
   }
 
   if (include.RStudio) {

--- a/man/cite_packages.Rd
+++ b/man/cite_packages.Rd
@@ -14,6 +14,7 @@ cite_packages(
   cite.tidyverse = TRUE,
   dependencies = FALSE,
   include.RStudio = FALSE,
+  passive.voice = FALSE,
   out.file = "grateful-report",
   bib.file = "grateful-refs",
   ...
@@ -73,6 +74,9 @@ If \code{TRUE}, will include all the packages that your used packages depend on.
 
 \item{include.RStudio}{Logical. If \code{TRUE}, adds a citation for the
 current version of RStudio.}
+
+\item{passive.voice}{Logical. If \code{TRUE}, uses passive voice in any paragraph
+generated for citations.}
 
 \item{out.file}{Desired name of the citation report to be created if
 \code{output = "file"}. Default is "grateful-report" (without extension).}

--- a/tests/testthat/test-cite_packages.R
+++ b/tests/testthat/test-cite_packages.R
@@ -53,6 +53,32 @@ test_that("cite_packages returns correct paragraph", {
                              class = "knit_asis",
                              knit_cacheable = NA))
 
+  ### passive voice
+
+  para <- cite_packages(output = "paragraph",
+                        pkgs = c("grateful"),
+                        out.dir = tempdir(),
+                        passive.voice = TRUE)
+
+  expect_identical(para,
+                   structure(paste0("This work was completed with the following R packages: grateful v. ",
+                                    utils::packageVersion("grateful"), " [@grateful]."),
+                             class = "knit_asis",
+                             knit_cacheable = NA))
+
+  para <- cite_packages(output = "paragraph",
+                        pkgs = "Session",
+                        out.dir = tempdir(),
+                        passive.voice = TRUE)
+
+  expect_identical(para,
+                   structure(paste0("This work was completed using R version ",
+                                    R.version$major, ".", R.version$minor,
+                                    " [@base] with the following R packages: testthat v. ",
+                                    utils::packageVersion("testthat"), " [@testthat]."),
+                             class = "knit_asis",
+                             knit_cacheable = NA))
+
 })
 
 


### PR DESCRIPTION
Adds a `passive.voice` option to `write_citation_paragraph()` as a partial solution to #33.